### PR TITLE
fix: use At method in speedykeyv over Get

### DIFF
--- a/include/sapp/FilesystemSearchProvider.h
+++ b/include/sapp/FilesystemSearchProvider.h
@@ -403,7 +403,7 @@ public:
 		auto &libKeyValue = libFolder["libraryfolders"];
 		for ( int i = 0; i < libKeyValue.ChildCount(); i++ )
 		{
-			KeyValue &folder = libKeyValue.Get( i );
+			KeyValue &folder = libKeyValue.At( i );
 			const char *name = folder.Key().string;
 			if ( !strcmp( name, "TimeNextStatsReport" ) || !strcmp( name, "ContentStatsID" ) )
 				continue;


### PR DESCRIPTION
Get is now deprecated, should use At here instead:
![Screenshot_20231114_200406](https://github.com/Trico-Everfire/SteamAppPathProvider/assets/26600014/cd4f2b84-3d2c-4c84-91db-f1f34a7fefc8)