### PR TITLE
fix: search for source 2 games using two directory levels instead of one

### DIFF
--- a/include/sapp/FilesystemSearchProvider.h
+++ b/include/sapp/FilesystemSearchProvider.h
@@ -569,10 +569,22 @@ public:
 
         for ( auto const &dir_entry : std::filesystem::directory_iterator { std::string( dirPath ), std::filesystem::directory_options::skip_permission_denied } )
         {
-            if ( dir_entry.is_directory() && std::filesystem::exists( dir_entry.path() / "gameinfo.gi" ) )
+            if ( !dir_entry.is_directory() )
+            {
+                continue;
+            }
+            if ( std::filesystem::exists( dir_entry.path() / "gameinfo.gi" ) )
             {
                 delete[] dirPath;
                 return true;
+            }
+            for ( auto const &subdir_entry : std::filesystem::directory_iterator { dir_entry.path(), std::filesystem::directory_options::skip_permission_denied } )
+            {
+                if ( subdir_entry.is_directory() && std::filesystem::exists( subdir_entry.path() / "gameinfo.gi" ) )
+                {
+                    delete[] dirPath;
+                    return true;
+                }
             }
         }
         delete[] dirPath;


### PR DESCRIPTION
Turns out that Source 2 games keep their gameinfo files a bit higher in the folder tree than Source 1 games. We can fix this by iterating over the second level of subdirectories as well, not only the first. Confirmed to work in VPKEdit (detected Counter-Strike 2)