### PR TITLE
fix: compilation, windows

### DIFF
--- a/include/sapp/SteamAppPathProvider.h
+++ b/include/sapp/SteamAppPathProvider.h
@@ -156,18 +156,18 @@ public:
         precacheSourceGames = shouldPrecacheSourceGames;
         precacheSource2Games = shouldPrecacheSource2Games;
 #ifdef _WIN32
-        std::string steamLocation;
-        steamLocation.resize(SAPP_MAX_PATH * 2);
+        char steamLocationData[SAPP_MAX_PATH * 2];
 
         HKEY steam;
         if ( RegOpenKeyExA( HKEY_LOCAL_MACHINE, R"(SOFTWARE\Valve\Steam)", 0, KEY_QUERY_VALUE | KEY_WOW64_32KEY, &steam ) != ERROR_SUCCESS )
             return;
 
-        DWORD dwSize = SAPP_MAX_PATH * 2;
-        if ( RegQueryValueExA( steam, "InstallPath", nullptr, nullptr, (LPBYTE)steamLocation.data(), &dwSize ) != ERROR_SUCCESS )
+        DWORD dwSize = sizeof(steamLocationData);
+        if ( RegQueryValueExA( steam, "InstallPath", nullptr, nullptr, (LPBYTE)steamLocationData, &dwSize ) != ERROR_SUCCESS )
             return;
 
         RegCloseKey( steam );
+        std::string steamLocation{ steamLocationData };
 
 #else
         std::string steamLocation;

--- a/include/sapp/SteamAppPathProvider.h
+++ b/include/sapp/SteamAppPathProvider.h
@@ -39,8 +39,8 @@ class ISteamSearchProvider
 {
 
 protected:
-    std::set<AppId_t> sourceGames;
-    std::set<AppId_t> source2Games;
+    std::unordered_set<AppId_t> sourceGames;
+    std::unordered_set<AppId_t> source2Games;
     bool precacheSourceGames = false;
     bool precacheSource2Games = false;
 


### PR DESCRIPTION
- Was using `std::set` but included `<unordered_set>` header
- Fixed Windows steam path string getting a null terminator thrown in